### PR TITLE
Fix calling with only flag argument yielidng "Empty argument"

### DIFF
--- a/bargs.sh
+++ b/bargs.sh
@@ -190,6 +190,8 @@ set_args_to_vars(){
                     elif [[ -z ${arg_dict[flag]} ]]; then
                         shift
                         value=$1
+                    elif [[ -n ${arg_dict[flag]} ]]; then
+                        value=$1
                     fi
 
                     if [[ -z $value && -n ${arg_dict[allow_env_var]} ]]; then


### PR DESCRIPTION
Hi there,
Doing something like `example.sh -hp` before this PR would yield 
```
[ERROR] Empty argument "happy"

Usage: <...>
```
This small addition should fix this behavior. I don't know this script all that well, but I ran the tests and they all seemed to pass. I would still like to ask for a review of this, as I'm not sure if I'm breaking crucial program logic here and just not seeing it :sweat_smile: 

Thanks for creating this awesome script :)

Cheers!

PS: Seems like Github automatically added a newline at the end of the file, hope this doesn't bother you :)