### PR TITLE
Support args with hyphens

### DIFF
--- a/bargs_vars
+++ b/bargs_vars
@@ -60,6 +60,11 @@ allow_env_var=true
 description=Username fetched from environment variable
 default=willywonka
 ---
+name=option-with-hyphens
+short=hy
+description=This option has hyphens, but the variable will be option_with_hyphens
+default=no value
+---
 name=bargs
 description=bash example.sh -n Willy --gender male -a 99
 default=irrelevant

--- a/example.sh
+++ b/example.sh
@@ -13,5 +13,6 @@ OS Language:           ~ $language
 I am happy:            ~ $happy
 CI Process:            ~ $CI
 Uppercased var names:  ~ $PERSON_NAME, $AGE years old, from $LOCATION
-Username from env var: ~ $username " \
+Username from env var: ~ $username 
+Option with hyphens:   ~ $option_with_hyphens" \
     | column -t -s "~"

--- a/tests.sh
+++ b/tests.sh
@@ -46,6 +46,7 @@ should pass "New Values" "source example.sh -a 23 --gender male -l=neverland -n 
 should pass "Valid Options" "source example.sh -a 23 --gender male -l neverland -n meir -f pizza -p=mypassword"
 should pass "Special Characters" "source example.sh -a 99 --gender male -s MxTZf+6K\HaAQlt\JWipe1oVRy -p mypassword"
 should pass "Use Flag" "source example.sh -a 23 --gender male --happy -p mypassword -ci"
+should pass "Option with hyphens" "source example.sh -a 23 -g male -p mypassword --option-with-hyphens some_value"
 should fail "Empty Argument" "source example.sh -a 99 --gender -p mypassword"
 should fail "Unknown Argument"  "source example.sh -a 99 -u meir -p mypassword"
 should fail "Invalid Options" "source example.sh -a 23 --gender male -l neverland -n meir -f notgood -p mypassword"


### PR DESCRIPTION
This PR adds support for hyphenated CLI args like:
`--option-with-hyphens`

The corresponding shell variable name is normalized to underscores like:
`$option_with_hyphens`

This behavior is similar to other argument parsing libraries, such as Python's argparse

I've also added an additional test exercising this feature