### PR TITLE
Document need for updated bash on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,10 @@ A utility for creating a Bash CLI application.
 
 ### macOS
 
+> Note: macOS ships with an outdated and incompatible `bash` version, so you need to install a newer one. If you install from homebrew, ensure `"$(brew --prefix)/bin"` is in your `$PATH`, ahead of `/usr/bin`.
+
 ```bash
+brew install bash
 brew install util-linux
 ```
 


### PR DESCRIPTION
macOS's `bash` is version 3.2.57, which is very out of date and incompatible with `bargs.sh`. This PR updates the README explaining this, and providing the appropriate `brew` command to install an updated one