### PR TITLE
Add bash version check

### DIFF
--- a/bargs.sh
+++ b/bargs.sh
@@ -12,7 +12,7 @@ _ARGS=""
 _NUM_OF_ARGS=0
 declare -A _LIST_ARGS_DICTS
 _NUM_OF_DICTS=0
-
+_MIN_BASH_VERSION="4.4"
 
 ### Functions
 error_msg(){
@@ -22,6 +22,19 @@ error_msg(){
     [[ -z $no_usage ]] && usage
     export DEBUG=1
     exit 1
+}
+
+version_greater_equal()
+{
+    # How to compare a program's version in a shell script?
+    # https://unix.stackexchange.com/a/567537
+    # $1: actual version
+    # $2: minimum required version
+    if [ -z "$2" ] || [ -z "$1" ];
+    then
+        return 1
+    fi
+    printf '%s\n%s\n' "$2" "$1" | sort --check=quiet --version-sort
 }
 
 
@@ -115,6 +128,12 @@ check_bargs_vars_path(){
     fi
 }
 
+check_bash_version(){
+    if ! version_greater_equal "$BASH_VERSION" "$_MIN_BASH_VERSION";
+    then
+        error_msg "Minimum bash version required: $_MIN_BASH_VERSION. Current version: $BASH_VERSION"
+    fi
+}
 
 read_bargs_vars(){
     # Reads the file, saving each arg as one string in the string ${args}
@@ -292,6 +311,7 @@ export_args_validation(){
 }
 
 ### Main
+check_bash_version
 read_bargs_vars
 args_to_list_dicts
 set_args_to_vars "$@" # <-- user input

--- a/tests.sh
+++ b/tests.sh
@@ -50,6 +50,21 @@ should fail "Empty Argument" "source example.sh -a 99 --gender -p mypassword"
 should fail "Unknown Argument"  "source example.sh -a 99 -u meir -p mypassword"
 should fail "Invalid Options" "source example.sh -a 23 --gender male -l neverland -n meir -f notgood -p mypassword"
 
+## Test recent, minimum, and outdated bash versions ##
+_tests_saved_bash_version="$BASH_VERSION"
+_tests_old_bash_version="3.2.57(1)-release"
+_tests_min_bash_version="4.4"
+_tests_recent_bash_version="5.1.16(1)-release"
+
+export BASH_VERSION="$_tests_recent_bash_version"
+should pass "Recent bash version: $_tests_recent_bash_version" "source example.sh -a 1 -g male -p password"
+export BASH_VERSION="$_tests_min_bash_version"
+should pass "Minimum bash version: $_tests_min_bash_version" "source example.sh -a 1 -g male -p password"
+export BASH_VERSION="$_tests_old_bash_version"
+should fail "Outdated bash version: $_tests_old_bash_version" "source example.sh -a 1 -g male -p password"
+# Restore proper BASH_VERSION
+export BASH_VERSION="$_tests_saved_bash_version"
+
 # bargs_vars path - fail
 mv bargs_vars bargs_vars1
 should fail "Missing bargs_vars" "source example.sh -h"


### PR DESCRIPTION
This PR adds a check that `$BASH_VERSION` is at least the minimum version (4.4 as stated in the README), and exits early if not.

I've also added tests for this functionality

When I was first trying out bargs.sh, I kept accidentally using the outdated system `bash` on macOS, and things would fail in weird and unexpected ways. This check should make that failure early and deterministic, and its cause clearer to the user.