### PR TITLE
added support for bash native flags e,o,x

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ wsl -u root -d Ubuntu-18.04 -- source example.sh
    - The delimiter `---` is required once at the beginning, and **twice** in the end
    - Characters which are not supported: `=`, `~`, `\`, `'`, `"`
    - The last variable `bargs` is necessary, comments below
-   - It's best to `source` bargs at the top of the bash script. **Do not** add `set -o pipefail` before `source bargs.sh`
+   - It's best to `source` bargs at the top of the bash script.
 
 ```
 ---
@@ -201,7 +201,7 @@ default=irrelevant
 
 </details>
 
-4. Add **one** of the following lines at the beginning of your application (see Usage below)
+1. Add **one** of the following lines at the beginning of your application (see Usage below)
 
    - `bargs.sh` is in the root folder of your project (just like in this repo)
      ```bash
@@ -212,7 +212,7 @@ default=irrelevant
      source "${PWD}"/"$(dirname ${BASH_SOURCE[0]})"/tools/bargs.sh "$@"
      ```
 
-5. The arguments are now available as environment variables, both lowercased and UPPERCASED (see Usage below)
+2. The arguments are now available as environment variables, both lowercased and UPPERCASED (see Usage below)
 
 ### Usage
 

--- a/bargs.sh
+++ b/bargs.sh
@@ -24,11 +24,6 @@ fi
 # Disable "set -e", "set -x" and "set -o pipefail"
 set +exo pipefail
 
-# trap ctrl-c and call ctrl_c()
-trap ctrl_c INT
-ctrl_c() {
-    exit 0
-}
 
 restore_values(){
     if [[ $_BARGS_SET_E_ENABLED -eq 1 ]]; then
@@ -40,6 +35,13 @@ restore_values(){
     if [[ $_BARGS_SET_O_ENABLED -eq 1 ]]; then
         set -o pipefail
     fi
+}
+
+# trap ctrl-c and call ctrl_c()
+trap ctrl_c INT
+ctrl_c() {
+    restore_values
+    exit 0
 }
 
 ### Global variables
@@ -219,6 +221,7 @@ set_args_to_vars(){
                 -h | --help )
                     usage
                     export DEBUG=0
+                    restore_values
                     exit 0
                 ;;
                 -"${arg_dict[short]}" | --"${arg_dict[name]}" )

--- a/bargs.sh
+++ b/bargs.sh
@@ -21,15 +21,25 @@ else
     _BARGS_SET_O_ENABLED=0
 fi
 
-# Disable set -e and set -x
-set +e
-set +x
-set +o pipefail
+# Disable "set -e", "set -x" and "set -o pipefail"
+set +exo pipefail
 
 # trap ctrl-c and call ctrl_c()
 trap ctrl_c INT
 ctrl_c() {
     exit 0
+}
+
+restore_values(){
+    if [[ $_BARGS_SET_E_ENABLED -eq 1 ]]; then
+        set -e
+    fi
+    if [[ $_BARGS_SET_X_ENABLED -eq 1 ]]; then
+        set -x
+    fi
+    if [[ $_BARGS_SET_O_ENABLED -eq 1 ]]; then
+        set -o pipefail
+    fi
 }
 
 ### Global variables
@@ -47,6 +57,7 @@ error_msg(){
     echo -e "[ERROR] $msg"
     [[ -z $no_usage ]] && usage
     export DEBUG=1
+    restore_values
     exit 1
 }
 
@@ -324,13 +335,4 @@ read_bargs_vars
 args_to_list_dicts
 set_args_to_vars "$@" # <-- user input
 export_args_validation
-# Restore values
-if [[ $_BARGS_SET_E_ENABLED -eq 1 ]]; then
-    set -e
-fi
-if [[ $_BARGS_SET_X_ENABLED -eq 1 ]]; then
-    set -x
-fi
-if [[ $_BARGS_SET_O_ENABLED -eq 1 ]]; then
-    set -o pipefail
-fi
+restore_values

--- a/bargs.sh
+++ b/bargs.sh
@@ -1,5 +1,31 @@
 #!/usr/bin/env bash
 
+# Check current "set -e" status and save it to a variable
+if [[ $- == *e* ]]; then
+    _BARGS_SET_E_ENABLED=1
+else
+    _BARGS_SET_E_ENABLED=0
+fi
+
+# Check current "set -x" status and save it to a variable
+if [[ $- == *x* ]]; then
+    _BARGS_SET_X_ENABLED=1
+else
+    _BARGS_SET_X_ENABLED=0
+fi
+
+# Check current "set -o pipefail" status and save it to a variable
+if [[ $- == *o* ]]; then
+    _BARGS_SET_O_ENABLED=1
+else
+    _BARGS_SET_O_ENABLED=0
+fi
+
+# Disable set -e and set -x
+set +e
+set +x
+set +o pipefail
+
 # trap ctrl-c and call ctrl_c()
 trap ctrl_c INT
 ctrl_c() {
@@ -298,3 +324,13 @@ read_bargs_vars
 args_to_list_dicts
 set_args_to_vars "$@" # <-- user input
 export_args_validation
+# Restore values
+if [[ $_BARGS_SET_E_ENABLED -eq 1 ]]; then
+    set -e
+fi
+if [[ $_BARGS_SET_X_ENABLED -eq 1 ]]; then
+    set -x
+fi
+if [[ $_BARGS_SET_O_ENABLED -eq 1 ]]; then
+    set -o pipefail
+fi

--- a/example.sh
+++ b/example.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -eo pipefail
 source "${PWD}"/"$(dirname ${BASH_SOURCE[0]})"/bargs.sh "$@"
 
 echo "


### PR DESCRIPTION
Fixes - #43 

This pull request includes several changes to improve the handling of bash script settings and update the README documentation. The most important changes include the addition of functions to save and restore bash settings in `bargs.sh`, and updates to the `README.md` file to correct the numbering and remove unnecessary instructions.

Improvements to bash script settings:

* [`bargs.sh`](diffhunk://#diff-73e1254bbe62d5c9d94097471d699761f06c88e11ff671427cdbc011fb86414dR3-R43): Added functions to check and save the current status of `set -e`, `set -x`, and `set -o pipefail`, and to restore these settings before exiting the script or handling errors. [[1]](diffhunk://#diff-73e1254bbe62d5c9d94097471d699761f06c88e11ff671427cdbc011fb86414dR3-R43) [[2]](diffhunk://#diff-73e1254bbe62d5c9d94097471d699761f06c88e11ff671427cdbc011fb86414dR62) [[3]](diffhunk://#diff-73e1254bbe62d5c9d94097471d699761f06c88e11ff671427cdbc011fb86414dR224) [[4]](diffhunk://#diff-73e1254bbe62d5c9d94097471d699761f06c88e11ff671427cdbc011fb86414dR341)
* [`example.sh`](diffhunk://#diff-db488d0b50f065c6149ea4762198bec704ba53b87aa35e41ab24543b0d5547a5L1-R3): Changed the shebang to use `#!/usr/bin/env bash` and added `set -eo pipefail` to ensure the script exits on errors and handles pipeline failures properly.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L115-R115): Removed the instruction to avoid `set -o pipefail` before sourcing `bargs.sh`.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L204-R204): Corrected the numbering of steps in the setup instructions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L204-R204) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L215-R215)